### PR TITLE
Long lived FileHandle in FileDestination

### DIFF
--- a/Sources/SwiftyBeaver/FileDestination.swift
+++ b/Sources/SwiftyBeaver/FileDestination.swift
@@ -9,6 +9,7 @@
 #if !os(Linux)
     import Foundation
 
+    // swiftlint:disable:next type_body_length
     open class FileDestination: BaseDestination {
         public var fileHandle: FileHandle?
         public var logFileURL: URL?

--- a/Sources/SwiftyBeaver/FileDestination.swift
+++ b/Sources/SwiftyBeaver/FileDestination.swift
@@ -223,7 +223,8 @@
 
         /// appends a string as line to a file.
         /// returns boolean about success
-        func saveToFile(str: String) -> Bool {
+        @_spi(Testable)
+        open func saveToFile(str: String) -> Bool {
             guard let url = logFileURL else {
                 Self.fallbackLog("No file URL found to save to.")
                 return false


### PR DESCRIPTION
Getting a new FileHandle and seeking to the end of the file for each write is really wasteful. Now, we hold on to a FileHandle and only create a new one after rotating files